### PR TITLE
Remove HintPaths from project definition

### DIFF
--- a/Source/CombatTrainingMod/CombatTrainingMod.csproj
+++ b/Source/CombatTrainingMod/CombatTrainingMod.csproj
@@ -32,15 +32,12 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="0Harmony">
-      <HintPath>..\..\..\..\..\..\..\..\..\..\Users\Kriil\projects\HugsLib_5.0.2\HugsLib\Assemblies\0Harmony.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Assembly-CSharp">
-      <HintPath>..\..\..\..\RimWorldWin64_Data\Managed\Assembly-CSharp.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="HugsLib">
-      <HintPath>..\..\..\..\..\..\..\..\..\..\Users\Kriil\projects\HugsLib_5.0.2\HugsLib\Assemblies\HugsLib.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="System" />
@@ -50,7 +47,6 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
     <Reference Include="UnityEngine">
-      <HintPath>..\..\..\..\RimWorldWin64_Data\Managed\UnityEngine.dll</HintPath>
       <Private>False</Private>
     </Reference>
   </ItemGroup>


### PR DESCRIPTION
HintPaths have been removed, as they're environment specific. Recommend using a .csproj.user file, with a ReferencePath declared.

Closes Kriil/rimworld-combat-training#5.