### PR TITLE
Update combat training to stop excessive training when xp caps are reached

### DIFF
--- a/Source/CombatTrainingMod/CombatTrainingMod.csproj
+++ b/Source/CombatTrainingMod/CombatTrainingMod.csproj
@@ -52,6 +52,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Building_CombatDummy.cs" />
+    <Compile Include="CombatTrainingTracker.cs" />
     <Compile Include="CombatTrainingController.cs" />
     <Compile Include="CombatTrainingDefOf.cs" />
     <Compile Include="Designator_BaseTrainCombat.cs" />

--- a/Source/CombatTrainingMod/CombatTrainingTracker.cs
+++ b/Source/CombatTrainingMod/CombatTrainingTracker.cs
@@ -119,7 +119,8 @@ namespace KriilMod_CD
 
             return null;
         }
-	}
+    }
+
     public class SkillXpValues
     {
         public int DayOfYear;

--- a/Source/CombatTrainingMod/CombatTrainingTracker.cs
+++ b/Source/CombatTrainingMod/CombatTrainingTracker.cs
@@ -4,11 +4,21 @@ using Verse;
 
 namespace KriilMod_CD
 {
+    /// <summary>
+    /// This class is used to track pawns' combat training xp to avoid having them continuously train.
+    /// It does this by keeping track of each pawn's current combat XP since midnight and comparing it to the pawn's current xp
+    /// to determine if they should skip the combat training job. 
+    /// For pawns with a skill less than level 20, this will have them train until they have maxed out training for the day,
+    /// and then restart them only if they drop below 3000 daily xp.
+    /// If they are at level 20 and max out their XP, then they will only train to max xp once on that day.
+    /// </summary>
 	public static class CombatTrainingTracker
 	{
         private static Dictionary<string, SkillXpValues> PawnMeleeSkillValues = new Dictionary<string, SkillXpValues>();
         private static Dictionary<string, SkillXpValues> PawnShootingSkillValues = new Dictionary<string, SkillXpValues>();
 
+        // TrackPawnMeleeSkill and TrackPawnShootingSkill are expected to be called when the pawn's combat training xp is updated.
+        // They store the pawn's combat xp for use in ShouldSkipCombatTraining.
         public static void TrackPawnMeleeSkill(Pawn pawn, SkillRecord skill)
         {
             int dayOfYear = GenLocalDate.DayOfYear(pawn);
@@ -21,45 +31,49 @@ namespace KriilMod_CD
             PawnShootingSkillValues[pawn.ThingID] = new SkillXpValues(dayOfYear, skill.xpSinceMidnight, skill.xpSinceLastLevel);
         }
 
-        /// <summary>
-        /// Determines if a pawn should skip combat training.
-        /// For pawns with a skill less than level 20, this will have them train until they have maxed out training for the day,
-        /// and then restart them only if they drop below 75% of max.
-        /// If they are at level 20, then they will only train to max xp once.
-        /// </summary>
-        /// <param name="pawn">The pawn that is eligible for training.</param>
-        /// <returns></returns>
 		public static bool ShouldSkipCombatTraining(Pawn pawn)
 		{
-            ClearYesterdaysShootingSkillValues(pawn);
+            // Reset the pawn's skill values if it is a new day.
+            ClearYesterdaysSkillValues(pawn);
 
             SkillRecord skill = GetCurrentSkill(pawn);
+
+            // Skip training if the max full rate xp has been reached today.
             if (skill.xpSinceMidnight > SkillRecord.MaxFullRateXpPerDay)
             {
                 return true;
             }
 
+            // If the pawn has already trained today then it will have a SkillXpValues object.
+            // If it does not then it has not trained today, so do not skip training.
             SkillXpValues lastSkillXpValues = GetLastSkillXpValues(pawn);
             if (lastSkillXpValues == null)
             {
                 return false;
             }
 
+            // If the pawn is 20 and hit the maximum possible XP during the last training session today, then skip training.
             if (skill.Level == 20 && lastSkillXpValues.XpSinceLastLevel >= skill.XpRequiredForLevelUp - 1f)
             {
                 return true;
             }
 
+            // If the pawn's last training session caused it to go over the max daily XP, but the skill has now degraded below 
+            // 75% of the max daily xp, then do not skip training.
             if (lastSkillXpValues.XpSinceMidnight >= SkillRecord.MaxFullRateXpPerDay)  
             {
                 return skill.xpSinceMidnight > SkillRecord.MaxFullRateXpPerDay * 0.75;
             }
 
+            // Otherwise, do not skip training.
             return false;
 		}
 
-        private static void ClearYesterdaysShootingSkillValues(Pawn pawn)
+        private static void ClearYesterdaysSkillValues(Pawn pawn)
         {
+            // This gets the day of the year in the pawn's local time, which is important because the daily XP reset is 
+            // done by using midnight in the pawn's local time. See Pawn_SkillTracker::SkillsTick()
+            // Here the day is used instead of the hour because it is not guaranteed that the job will be checked every hour, or even every day.
             int dayOfYear = GenLocalDate.DayOfYear(pawn);
             if (PawnMeleeSkillValues.ContainsKey(pawn.ThingID) && PawnMeleeSkillValues[pawn.ThingID].DayOfYear != dayOfYear)
             { 

--- a/Source/CombatTrainingMod/CombatTrainingTracker.cs
+++ b/Source/CombatTrainingMod/CombatTrainingTracker.cs
@@ -1,0 +1,122 @@
+﻿using System.Collections.Generic;
+using RimWorld;
+using Verse;
+
+namespace KriilMod_CD
+{
+	public static class CombatTrainingTracker
+	{
+        private static Dictionary<string, SkillXpValues> PawnMeleeSkillValues = new Dictionary<string, SkillXpValues>();
+        private static Dictionary<string, SkillXpValues> PawnShootingSkillValues = new Dictionary<string, SkillXpValues>();
+
+        public static void TrackPawnMeleeSkill(Pawn pawn, SkillRecord skill)
+        {
+            int dayOfYear = GenLocalDate.DayOfYear(pawn);
+            PawnMeleeSkillValues[pawn.ThingID] = new SkillXpValues(dayOfYear, skill.xpSinceMidnight, skill.xpSinceLastLevel);
+        }
+
+        public static void TrackPawnShootingSkill(Pawn pawn, SkillRecord skill)
+        {
+            int dayOfYear = GenLocalDate.DayOfYear(pawn);
+            PawnShootingSkillValues[pawn.ThingID] = new SkillXpValues(dayOfYear, skill.xpSinceMidnight, skill.xpSinceLastLevel);
+        }
+
+        /// <summary>
+        /// Determines if a pawn should skip combat training.
+        /// For pawns with a skill less than level 20, this will have them train until they have maxed out training for the day,
+        /// and then restart them only if they drop below 75% of max.
+        /// If they are at level 20, then they will only train to max xp once.
+        /// </summary>
+        /// <param name="pawn">The pawn that is eligible for training.</param>
+        /// <returns></returns>
+		public static bool ShouldSkipCombatTraining(Pawn pawn)
+		{
+            ClearYesterdaysShootingSkillValues(pawn);
+
+            SkillRecord skill = GetCurrentSkill(pawn);
+            if (skill.xpSinceMidnight > SkillRecord.MaxFullRateXpPerDay)
+            {
+                return true;
+            }
+
+            SkillXpValues lastSkillXpValues = GetLastSkillXpValues(pawn);
+            if (lastSkillXpValues == null)
+            {
+                return false;
+            }
+
+            if (skill.Level == 20 && lastSkillXpValues.XpSinceLastLevel >= skill.XpRequiredForLevelUp - 1f)
+            {
+                return true;
+            }
+
+            if (lastSkillXpValues.XpSinceMidnight >= SkillRecord.MaxFullRateXpPerDay)  
+            {
+                return skill.xpSinceMidnight > SkillRecord.MaxFullRateXpPerDay * 0.75;
+            }
+
+            return false;
+		}
+
+        private static void ClearYesterdaysShootingSkillValues(Pawn pawn)
+        {
+            int dayOfYear = GenLocalDate.DayOfYear(pawn);
+            if (PawnMeleeSkillValues.ContainsKey(pawn.ThingID) && PawnMeleeSkillValues[pawn.ThingID].DayOfYear != dayOfYear)
+            { 
+                PawnMeleeSkillValues.Remove(pawn.ThingID);
+            }
+            if (PawnShootingSkillValues.ContainsKey(pawn.ThingID) && PawnShootingSkillValues[pawn.ThingID].DayOfYear != dayOfYear)
+            {
+                PawnShootingSkillValues.Remove(pawn.ThingID);
+            }
+        }
+
+        private static SkillRecord GetCurrentSkill(Pawn pawn)
+        {
+            SkillRecord shooting = pawn.skills.GetSkill(SkillDefOf.Shooting);
+            SkillRecord melee = pawn.skills.GetSkill(SkillDefOf.Melee);
+            var weapon = pawn.equipment.Primary;
+
+            if (weapon == null)
+            {
+                return melee;
+            }
+
+            if (weapon.def.IsRangedWeapon)
+            {
+                return shooting;
+            }
+
+            return melee;
+        }
+
+        private static SkillXpValues GetLastSkillXpValues(Pawn pawn)
+        {
+            var weapon = pawn.equipment.Primary;
+
+            if (weapon != null && weapon.def.IsRangedWeapon && PawnShootingSkillValues.ContainsKey(pawn.ThingID))
+            {
+                return PawnShootingSkillValues[pawn.ThingID];
+            }
+            else if (PawnMeleeSkillValues.ContainsKey(pawn.ThingID))
+            {
+                return PawnMeleeSkillValues[pawn.ThingID];
+            }
+
+            return null;
+        }
+	}
+    public class SkillXpValues
+    {
+        public int DayOfYear;
+        public float XpSinceMidnight;
+        public float XpSinceLastLevel;
+        public SkillXpValues(int dayOfYear, float xpSinceMidnight, float xpSinceLastLevel)
+        {
+            this.DayOfYear = dayOfYear;
+            this.XpSinceMidnight = xpSinceMidnight;
+            this.XpSinceLastLevel = xpSinceLastLevel;
+        }
+    }
+}
+

--- a/Source/CombatTrainingMod/CombatTrainingTracker.cs
+++ b/Source/CombatTrainingMod/CombatTrainingTracker.cs
@@ -12,8 +12,8 @@ namespace KriilMod_CD
     /// and then restart them only if they drop below 3000 daily xp.
     /// If they are at level 20 and max out their XP, then they will only train to max xp once on that day.
     /// </summary>
-	public static class CombatTrainingTracker
-	{
+    public static class CombatTrainingTracker
+    {
         private static Dictionary<string, SkillXpValues> PawnMeleeSkillValues = new Dictionary<string, SkillXpValues>();
         private static Dictionary<string, SkillXpValues> PawnShootingSkillValues = new Dictionary<string, SkillXpValues>();
 
@@ -31,8 +31,8 @@ namespace KriilMod_CD
             PawnShootingSkillValues[pawn.ThingID] = new SkillXpValues(dayOfYear, skill.xpSinceMidnight, skill.xpSinceLastLevel);
         }
 
-		public static bool ShouldSkipCombatTraining(Pawn pawn)
-		{
+        public static bool ShouldSkipCombatTraining(Pawn pawn)
+        {
             // Reset the pawn's skill values if it is a new day.
             ClearYesterdaysSkillValues(pawn);
 
@@ -67,7 +67,7 @@ namespace KriilMod_CD
 
             // Otherwise, do not skip training.
             return false;
-		}
+        }
 
         private static void ClearYesterdaysSkillValues(Pawn pawn)
         {

--- a/Source/CombatTrainingMod/WorkGiver_TrainCombat.cs
+++ b/Source/CombatTrainingMod/WorkGiver_TrainCombat.cs
@@ -41,7 +41,7 @@ namespace KriilMod_CD
             }
             else
             {
-                return pawn.skills.GetSkill(SkillDefOf.Melee).LearningSaturatedToday || pawn.skills.GetSkill(SkillDefOf.Shooting).LearningSaturatedToday;
+                return CombatTrainingTracker.ShouldSkipCombatTraining(pawn);
             }
         }
 


### PR DESCRIPTION
Pawns with a high skill level that trained to 4000 xp in one day would enter a loop where they would go do one other task, have their xp decay below 4000 xp, and then return to the training room to fire a few shots to get above 4000 xp and repeating. This creates an inefficiency because the pawns are spending lots of time traveling to and from the combat room with little benefit.

Additionally, pawns that reached max xp on level 20 would never break over 4000 xp in a day because their xp is capped at 29999 and they only degrade a maximum of 3600 xp in one day. This meant they would train nearly indefinitely unless you changed their work priorities. 

This PR fixes these issues by:
1. Having a pawn skip a combat training job if it has already trained 4000xp in that day and has not yet decayed below 3000 daily xp, or if it is level 20 and has reached the max xp already that day.
2. Having a pawn stop combat training if it has reached the xp cap of 29999.

I tried to look for a less stateful way to do this, but I concluded there is no way to determine if a pawn has already trained in a given day unless you store that fact. So I created `CombatTrainingTracker` which stores the skill xp values for each pawn when they train. Then when `CombatTrainingTracker.ShouldSkipCombatTraining()` is queried it can look at the pawn's last training state along with the current training state to determine if it should skip training or not.

This does still have the issue that when you load a game, pawns will all go to train even if they have already trained this day. However that can't be fixed without adding something to the save file, and the pawns will correctly go train themselves back to full and then not train again that day.


